### PR TITLE
Add D3D user annotations for profiling and debug

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -114,6 +114,8 @@ HRESULT DeviceResources::Initialize()
 		hr = D3D11CreateDevice(nullptr, this->_d3dDriverType, nullptr, createDeviceFlags, featureLevels, numFeatureLevels, D3D11_SDK_VERSION, &this->_d3dDevice, &this->_d3dFeatureLevel, &this->_d3dDeviceContext);
 	}
 
+	this->_d3dDeviceContext->QueryInterface(__uuidof(ID3DUserDefinedAnnotation), (void**)&this->_d3dAnnotation);
+
 	if (SUCCEEDED(hr))
 	{
 		hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &this->_d2d1Factory);
@@ -887,6 +889,8 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 	ID3D11Texture2D* tex = nullptr;
 	ID3D11ShaderResourceView* texView = nullptr;
 
+	this->_d3dAnnotation->BeginEvent(L"RenderMain");
+
 	if (SUCCEEDED(hr))
 	{
 		if ((width == this->_displayWidth) && (height == this->_displayHeight) && (bpp == this->_mainDisplayTextureBpp))
@@ -1241,6 +1245,8 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 
 		messageShown = true;
 	}
+
+	this->_d3dAnnotation->EndEvent();
 
 	return hr;
 }

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -67,6 +67,8 @@ DeviceResources::DeviceResources()
 	this->_are16BppTexturesSupported = false;
 	this->_use16BppMainDisplayTexture = false;
 
+	this->_d3dAnnotation = nullptr;
+
 	// TODO
 	//const float color[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
 	const float color[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
@@ -114,7 +116,7 @@ HRESULT DeviceResources::Initialize()
 		hr = D3D11CreateDevice(nullptr, this->_d3dDriverType, nullptr, createDeviceFlags, featureLevels, numFeatureLevels, D3D11_SDK_VERSION, &this->_d3dDevice, &this->_d3dFeatureLevel, &this->_d3dDeviceContext);
 	}
 
-	this->_d3dDeviceContext->QueryInterface(__uuidof(ID3DUserDefinedAnnotation), (void**)&this->_d3dAnnotation);
+	this->_d3dDeviceContext.As(&this->_d3dAnnotation);
 
 	if (SUCCEEDED(hr))
 	{
@@ -889,7 +891,7 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 	ID3D11Texture2D* tex = nullptr;
 	ID3D11ShaderResourceView* texView = nullptr;
 
-	this->_d3dAnnotation->BeginEvent(L"RenderMain");
+	BeginAnnotatedEvent(L"RenderMain");
 
 	if (SUCCEEDED(hr))
 	{
@@ -1406,4 +1408,26 @@ bool DeviceResources::IsTextureFormatSupported(DXGI_FORMAT format)
 	const UINT expected = D3D11_FORMAT_SUPPORT_TEXTURE2D | D3D11_FORMAT_SUPPORT_MIP | D3D11_FORMAT_SUPPORT_SHADER_LOAD | D3D11_FORMAT_SUPPORT_CPU_LOCKABLE;
 
 	return (formatSupport & expected) == expected;
+}
+
+bool DeviceResources::BeginAnnotatedEvent(_In_ LPCWSTR Name)
+{
+	if (_d3dAnnotation != nullptr)
+	{
+		_d3dAnnotation->BeginEvent(Name);
+		return true;
+	}
+	else
+		return false;
+}
+
+bool DeviceResources::EndAnnotatedEvent()
+{
+	if (_d3dAnnotation != nullptr)
+	{
+		_d3dAnnotation->EndEvent();
+		return true;
+	}
+	else
+		return false;
 }

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1248,7 +1248,7 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 		messageShown = true;
 	}
 
-	this->_d3dAnnotation->EndEvent();
+	this->EndAnnotatedEvent();
 
 	return hr;
 }

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -74,6 +74,7 @@ public:
 	ComPtr<ID3D11RenderTargetView> _renderTargetView;
 	ComPtr<ID3D11Texture2D> _depthStencil;
 	ComPtr<ID3D11DepthStencilView> _depthStencilView;
+	ComPtr<ID3DUserDefinedAnnotation> _d3dAnnotation;
 
 	ComPtr<ID2D1Factory> _d2d1Factory;
 	ComPtr<IDWriteFactory> _dwriteFactory;

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -57,6 +57,9 @@ public:
 
 	bool IsTextureFormatSupported(DXGI_FORMAT format);
 
+	bool BeginAnnotatedEvent(_In_ LPCWSTR Name);
+	bool EndAnnotatedEvent();
+
 	DWORD _displayWidth;
 	DWORD _displayHeight;
 	DWORD _displayBpp;

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -472,6 +472,8 @@ HRESULT Direct3DDevice::Execute(
 	DWORD dwFlags
 )
 {
+	_deviceResources->_d3dAnnotation->BeginEvent(L"Execute");
+
 #if LOGGER
 	std::ostringstream str;
 	str << this << " " << __FUNCTION__;
@@ -792,6 +794,8 @@ HRESULT Direct3DDevice::Execute(
 		}
 	}
 
+	_deviceResources->_d3dAnnotation->EndEvent();
+
 	if (FAILED(hr))
 	{
 		static bool messageShown = false;
@@ -1089,6 +1093,9 @@ HRESULT Direct3DDevice::DeleteMatrix(
 
 HRESULT Direct3DDevice::BeginScene()
 {
+
+	_deviceResources->_d3dAnnotation->BeginEvent(L"Direct3DDeviceScene");
+
 #if LOGGER
 	std::ostringstream str;
 	str << this << " " << __FUNCTION__;
@@ -1173,6 +1180,8 @@ HRESULT Direct3DDevice::EndScene()
 			+ " V=" + std::to_string(g_ExecuteVertexCount)
 			+ " I=" + std::to_string(g_ExecuteIndexCount)).c_str());
 	}*/
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 
 	return D3D_OK;
 }

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -472,7 +472,7 @@ HRESULT Direct3DDevice::Execute(
 	DWORD dwFlags
 )
 {
-	_deviceResources->_d3dAnnotation->BeginEvent(L"Execute");
+	_deviceResources->BeginAnnotatedEvent(L"Execute");
 
 #if LOGGER
 	std::ostringstream str;
@@ -794,7 +794,7 @@ HRESULT Direct3DDevice::Execute(
 		}
 	}
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 
 	if (FAILED(hr))
 	{
@@ -1094,7 +1094,7 @@ HRESULT Direct3DDevice::DeleteMatrix(
 HRESULT Direct3DDevice::BeginScene()
 {
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"Direct3DDeviceScene");
+	_deviceResources->BeginAnnotatedEvent(L"Direct3DDeviceScene");
 
 #if LOGGER
 	std::ostringstream str;
@@ -1181,7 +1181,7 @@ HRESULT Direct3DDevice::EndScene()
 			+ " I=" + std::to_string(g_ExecuteIndexCount)).c_str());
 	}*/
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 
 	return D3D_OK;
 }

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -358,7 +358,7 @@ HRESULT PrimarySurface::Flip(
 	DWORD dwFlags
 	)
 {
-	_deviceResources->_d3dAnnotation->BeginEvent(L"PrimarySurfaceFlip");
+	_deviceResources->BeginAnnotatedEvent(L"PrimarySurfaceFlip");
 
 #if LOGGER
 	std::ostringstream str;
@@ -407,7 +407,7 @@ HRESULT PrimarySurface::Flip(
 			if (FAILED(hr = this->_deviceResources->_backbufferSurface->BltFast(0, 0, this->_deviceResources->_frontbufferSurface, nullptr, 0)))
 				return hr;
 
-			_deviceResources->_d3dAnnotation->EndEvent();
+			this->_deviceResources->EndAnnotatedEvent();
 			return this->Flip(this->_deviceResources->_backbufferSurface, 0);
 		}
 
@@ -533,7 +533,7 @@ HRESULT PrimarySurface::Flip(
 				this->_deviceResources->_frontbufferSurface->wasBltFastCalled = false;
 			}
 
-			_deviceResources->_d3dAnnotation->EndEvent();
+			this->_deviceResources->EndAnnotatedEvent();
 			return hr;
 		}
 	}
@@ -576,7 +576,7 @@ HRESULT PrimarySurface::Flip(
 		{
 			hr = DD_OK;
 		}
-		_deviceResources->_d3dAnnotation->EndEvent();
+		this->_deviceResources->EndAnnotatedEvent();
 		return hr;
 	}
 
@@ -585,7 +585,7 @@ HRESULT PrimarySurface::Flip(
 	LogText(str.str());
 #endif
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	this->_deviceResources->EndAnnotatedEvent();
 	return DDERR_UNSUPPORTED;
 }
 
@@ -1120,7 +1120,7 @@ void PrimarySurface::RenderText()
 		return;
 	}
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderText");
+	this->_deviceResources->BeginAnnotatedEvent(L"RenderText");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -1246,7 +1246,7 @@ void PrimarySurface::RenderText()
 	g_xwa_text.clear();
 	g_xwa_text.reserve(4096);
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	this->_deviceResources->EndAnnotatedEvent();
 }
 
 void PrimarySurface::RenderRadar()
@@ -1270,7 +1270,7 @@ void PrimarySurface::RenderRadar()
 		return;
 	}
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderRadar");
+	this->_deviceResources->BeginAnnotatedEvent(L"RenderRadar");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -1372,7 +1372,7 @@ void PrimarySurface::RenderRadar()
 	g_xwa_radar_selected_positionX = -1;
 	g_xwa_radar_selected_positionY = -1;
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	this->_deviceResources->EndAnnotatedEvent();
 }
 
 void PrimarySurface::RenderBracket()
@@ -1396,7 +1396,7 @@ void PrimarySurface::RenderBracket()
 		return;
 	}
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderBracket");
+	this->_deviceResources->BeginAnnotatedEvent(L"RenderBracket");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -1508,5 +1508,5 @@ void PrimarySurface::RenderBracket()
 
 	g_xwa_bracket.clear();
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	this->_deviceResources->EndAnnotatedEvent();
 }

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -358,6 +358,8 @@ HRESULT PrimarySurface::Flip(
 	DWORD dwFlags
 	)
 {
+	_deviceResources->_d3dAnnotation->BeginEvent(L"PrimarySurfaceFlip");
+
 #if LOGGER
 	std::ostringstream str;
 	str << this << " " << __FUNCTION__;
@@ -405,6 +407,7 @@ HRESULT PrimarySurface::Flip(
 			if (FAILED(hr = this->_deviceResources->_backbufferSurface->BltFast(0, 0, this->_deviceResources->_frontbufferSurface, nullptr, 0)))
 				return hr;
 
+			_deviceResources->_d3dAnnotation->EndEvent();
 			return this->Flip(this->_deviceResources->_backbufferSurface, 0);
 		}
 
@@ -530,6 +533,7 @@ HRESULT PrimarySurface::Flip(
 				this->_deviceResources->_frontbufferSurface->wasBltFastCalled = false;
 			}
 
+			_deviceResources->_d3dAnnotation->EndEvent();
 			return hr;
 		}
 	}
@@ -572,7 +576,7 @@ HRESULT PrimarySurface::Flip(
 		{
 			hr = DD_OK;
 		}
-
+		_deviceResources->_d3dAnnotation->EndEvent();
 		return hr;
 	}
 
@@ -581,6 +585,7 @@ HRESULT PrimarySurface::Flip(
 	LogText(str.str());
 #endif
 
+	_deviceResources->_d3dAnnotation->EndEvent();
 	return DDERR_UNSUPPORTED;
 }
 
@@ -1115,6 +1120,8 @@ void PrimarySurface::RenderText()
 		return;
 	}
 
+	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderText");
+
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
 		s_d2d1RenderTarget = this->_deviceResources->_d2d1RenderTarget;
@@ -1238,6 +1245,8 @@ void PrimarySurface::RenderText()
 
 	g_xwa_text.clear();
 	g_xwa_text.reserve(4096);
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void PrimarySurface::RenderRadar()
@@ -1260,6 +1269,8 @@ void PrimarySurface::RenderRadar()
 		s_brush.Release();
 		return;
 	}
+
+	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderRadar");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -1360,6 +1371,8 @@ void PrimarySurface::RenderRadar()
 	g_xwa_radar.clear();
 	g_xwa_radar_selected_positionX = -1;
 	g_xwa_radar_selected_positionY = -1;
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void PrimarySurface::RenderBracket()
@@ -1382,6 +1395,8 @@ void PrimarySurface::RenderBracket()
 		s_brush.Release();
 		return;
 	}
+
+	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderBracket");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -1492,4 +1507,6 @@ void PrimarySurface::RenderBracket()
 	this->_deviceResources->_d2d1RenderTarget->RestoreDrawingState(this->_deviceResources->_d2d1DrawingStateBlock);
 
 	g_xwa_bracket.clear();
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 }

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -282,6 +282,8 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 {
 	_deviceResources = deviceResources;
 
+	_deviceResources->_d3dAnnotation->BeginEvent(L"D3dRendererScene");
+
 	if (!_isInitialized)
 	{
 		Initialize();
@@ -304,6 +306,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 
 void D3dRenderer::SceneEnd()
 {
+	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void D3dRenderer::FlightStart()
@@ -327,7 +330,6 @@ void D3dRenderer::MainSceneHook(const SceneCompData* scene)
 	ComPtr<ID3D11Buffer> oldVSConstantBuffer;
 	ComPtr<ID3D11Buffer> oldPSConstantBuffer;
 	ComPtr<ID3D11ShaderResourceView> oldVSSRV[3];
-
 	context->VSGetConstantBuffers(0, 1, oldVSConstantBuffer.GetAddressOf());
 	context->PSGetConstantBuffers(0, 1, oldPSConstantBuffer.GetAddressOf());
 	context->VSGetShaderResources(0, 3, oldVSSRV[0].GetAddressOf());
@@ -379,7 +381,6 @@ void D3dRenderer::HangarShadowSceneHook(const SceneCompData* scene)
 	ComPtr<ID3D11Buffer> oldVSConstantBuffer;
 	ComPtr<ID3D11Buffer> oldPSConstantBuffer;
 	ComPtr<ID3D11ShaderResourceView> oldVSSRV[3];
-
 	context->VSGetConstantBuffers(0, 1, oldVSConstantBuffer.GetAddressOf());
 	context->PSGetConstantBuffers(0, 1, oldPSConstantBuffer.GetAddressOf());
 	context->VSGetShaderResources(0, 3, oldVSSRV[0].GetAddressOf());
@@ -818,7 +819,6 @@ void D3dRenderer::RenderScene()
 	}
 
 	ID3D11DeviceContext* context = _deviceResources->_d3dDeviceContext;
-
 	unsigned short scissorLeft = *(unsigned short*)0x07D5244;
 	unsigned short scissorTop = *(unsigned short*)0x07CA354;
 	unsigned short scissorWidth = *(unsigned short*)0x08052B8;

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -282,7 +282,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 {
 	_deviceResources = deviceResources;
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"D3dRendererScene");
+	_deviceResources->BeginAnnotatedEvent(L"D3dRendererScene");
 
 	if (!_isInitialized)
 	{
@@ -306,7 +306,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 
 void D3dRenderer::SceneEnd()
 {
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }
 
 void D3dRenderer::FlightStart()

--- a/impl11/ddraw/common.h
+++ b/impl11/ddraw/common.h
@@ -14,6 +14,7 @@ extern bool _IsXwaExe;
 
 #include <dxgi.h>
 #include <d3d11.h>
+#include <d3d11_1.h>
 #include <d2d1.h>
 #include <d2d1helper.h>
 #include <dwrite.h>


### PR DESCRIPTION
GPU performance events can be used to instrument your game by labeling regions and marking important occurrences. A performance event represents a logical, hierarchical grouping of work, consisting of a begin/end marker pair.
In Direct3D 11.1 and above, the ID3DUserDefinedAnnotation interface is the recommended way to define those events.

https://docs.microsoft.com/en-us/windows/win32/api/d3d11_1/nn-d3d11_1-id3duserdefinedannotation
https://developer.nvidia.com/blog/best-practices-gpu-performance-events/

These annotations can be used by different profiling tools, like Intel GPA, PIX, RenderDoc, NVIDIA Nsight... I could only do a capture with Intel GPA though.

![image](https://user-images.githubusercontent.com/2017580/178916045-22f2cfe6-9e41-40d0-b70e-8a4049e190b3.png)

The methods of ID3DUserDefinedAnnotation have no effect when the calling application is not running under a Direct3D-specific profiling tool.

To make them work I had to include d3d11_1.h.
I added a new property in DeviceResources that should be available everywhere that this functionality is needed.
I added some events for the high level functions that are performing draw calls.